### PR TITLE
個人の今週・先週勉強集計を出力するコマンドを作成

### DIFF
--- a/Cogs/Aggregationtime/personalDayRecord.py
+++ b/Cogs/Aggregationtime/personalDayRecord.py
@@ -87,8 +87,10 @@ class Personal_DayRecord(commands.Cog):
     def create_twitter_embed(self, sendMessage):
         longUrl = self.createTwitterUrlEncode("https://mo9mo9study.github.io/discord.web/", sendMessage)
         encodeMessage = self.shorten_url(longUrl, self.googleShortLinksPrefix , self.googleApiKey)
-        embed = discord.Embed(title="積み上げツイート用",description=sendMessage,color=0xFDB46C)
-        embed.add_field(name="⬇︎下のURLから簡単に積み上げツイートが出来るよ",value=encodeMessage)
+        #embed = discord.Embed(title="積み上げツイート用",description=sendMessage,color=0xFDB46C)
+        embed = discord.Embed(title="📤積み上げツイート用",description=sendMessage,color=0xFDB46C)
+        #embed.add_field(name="⬇︎下のURLから簡単に積み上げツイートが出来るよ",value=encodeMessage)
+        embed.add_field(name="🦜下のURLから簡単に積み上げツイートが出来るよ",value=encodeMessage)
         return embed
 
 

--- a/Cogs/Aggregationtime/personalDayRecord.py
+++ b/Cogs/Aggregationtime/personalDayRecord.py
@@ -84,6 +84,14 @@ class Personal_DayRecord(commands.Cog):
         return day_result
 
 
+    def create_twitter_embed(self, sendMessage):
+        longUrl = self.createTwitterUrlEncode("https://mo9mo9study.github.io/discord.web/", sendMessage)
+        encodeMessage = self.shorten_url(longUrl, self.googleShortLinksPrefix , self.googleApiKey)
+        embed = discord.Embed(title="積み上げツイート用",description=sendMessage,color=0xFDB46C)
+        embed.add_field(name="⬇︎下のURLから簡単に積み上げツイートが出来るよ",value=encodeMessage)
+        return embed
+
+
     @commands.group(invoke_without_command=True)
     async def result_d(self, ctx):
         #当日分の日次集計
@@ -96,10 +104,11 @@ class Personal_DayRecord(commands.Cog):
             strtoday = datetime.strftime(today, '%Y-%m-%d')
             sum_study_time = self.aggregate_day_users_record(name, strtoday)
             sendMessage = self.compose_user_record(name, strtoday, sum_study_time)
-            longUrl = self.createTwitterUrlEncode("https://mo9mo9study.github.io/discord.web/", sendMessage)
-            encodeMessage = self.shorten_url(longUrl, self.googleShortLinksPrefix , self.googleApiKey)
-            embed = discord.Embed(title="積み上げツイート用",description=sendMessage,color=0xFDB46C)
-            embed.add_field(name="⬇︎下のURLから簡単に積み上げツイートが出来るよ",value=encodeMessage)
+            #longUrl = self.createTwitterUrlEncode("https://mo9mo9study.github.io/discord.web/", sendMessage)
+            #encodeMessage = self.shorten_url(longUrl, self.googleShortLinksPrefix , self.googleApiKey)
+            #embed = discord.Embed(title="積み上げツイート用",description=sendMessage,color=0xFDB46C)
+            #embed.add_field(name="⬇︎下のURLから簡単に積み上げツイートが出来るよ",value=encodeMessage)
+            embed = self.create_twitter_embed(sendMessage)
             sendmsg = await ctx.send(embed=embed)
             await sendmsg.add_reaction("<:otsukaresama:757813789952573520>")
         else:

--- a/Cogs/Aggregationtime/personalWeekRecord.py
+++ b/Cogs/Aggregationtime/personalWeekRecord.py
@@ -1,0 +1,103 @@
+from datetime import date, datetime, timedelta
+
+import discord
+from discord.ext import commands
+import asyncio
+import urllib.parse
+import json
+import requests
+
+from .weekAggregate import Week_Aggregate
+from .personalDayRecord import Personal_DayRecord
+
+
+class Personal_WeekRecord(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.LOG_DIR = "/home/centos/repos/discord.VCtimeRecord/entry_exit/timelog/"
+    
+    def getlastweek_days(self):
+        weeknumber = [0, 1, 2, 3, 4, 5, 6]
+        lastweek_days = []
+        for i in weeknumber:
+            lastweek_day = date.today() - timedelta(days=datetime.now().weekday()) + timedelta(days=i, weeks=-1)
+            lastweek_days.append(lastweek_day.strftime("%Y-%m-%d"))
+        lastsunday = datetime.now().strptime(lastweek_days[-1], "%Y-%m-%d").strftime("%m-%d")
+        desc_lastweek = f"{lastweek_days[0]}〜{lastsunday}"
+        return lastweek_days, desc_lastweek
+    
+    def getweek_days(self):
+        # 月曜(0)から今日の曜日までの曜日を示す数字を配列に格納
+        weeknumber = list(range(date.today().weekday() + 1))
+        week_days = []
+        for i in weeknumber:
+            week_day = date.today() - timedelta(days=datetime.now().weekday()) + timedelta(days=i)
+            week_days.append(week_day.strftime("%Y-%m-%d")) 
+        now_date = datetime.now().strftime("%m-%d")
+        desc_week = f"{week_days[0]}〜{now_date}"
+        return week_days, desc_week
+    
+
+
+    def format_userrecord(self, name, day, studytime, title):
+        totalStudyTime=str(Week_Aggregate(self.bot).minutes2time(studytime)).strip()
+        week_result = f'''
+#{title}
+- 
+-
+
+#もくもくオンライン勉強会 
+[ {day}の勉強時間 ]
+---> {totalStudyTime}
+#mo9mo9_{name}
+        '''
+        return week_result
+
+    
+    def aggregate_user_record(self, username, week_days):
+        # ユーザーの勉強記録を取得
+        lines_strip = Week_Aggregate(self.bot).read_file(f"{self.LOG_DIR}{username}")
+        study_logs = []
+        for line in lines_strip:
+            if "Study time" in line:
+                study_logs += [line for day in week_days if day in line]
+        # 先週分の勉強記録を取得
+        study_days = []
+        for log in study_logs:
+            study_days += [day[-5:] for day in week_days if day in log]
+        # 総勉強時間を取得
+        sum_studytime = 0
+        for log in study_logs:
+            sum_studytime += int(log.split(",")[-1])
+        return sum_studytime
+
+
+
+    @commands.group(invoke_without_command=True)
+    async def result_w(self, ctx):
+        if ctx.subcommand_passed is None:
+            username = ctx.author.name
+            week_days, desc_week = self.getweek_days()
+            sum_studytime = self.aggregate_user_record(username, week_days)
+            sendmessage = self.format_userrecord(username, desc_week, sum_studytime, "今週の振り返り")
+            print(sendmessage)
+            embed = Personal_DayRecord(self.bot).create_twitter_embed(sendmessage)
+            await ctx.channel.send(embed=embed)
+        else:
+            await ctx.send("[ " + ctx.subcommand_passed + " ]は無効な引数です")
+
+
+    @result_w.command()
+    async def ago(self, ctx):
+        username = ctx.author.name
+        lastweek_days, desc_lastweek = self.getlastweek_days()
+        sum_studytime = self.aggregate_user_record(username, lastweek_days)
+        sendmessage = self.format_userrecord(username, desc_lastweek, sum_studytime, "先週の振り返り")
+        print(sendmessage)
+        embed = Personal_DayRecord(self.bot).create_twitter_embed(sendmessage)
+        await ctx.channel.send(embed=embed)
+
+
+def setup(bot):
+    return bot.add_cog(Personal_WeekRecord(bot))

--- a/Cogs/Aggregationtime/personalWeekRecord.py
+++ b/Cogs/Aggregationtime/personalWeekRecord.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+import re
 
 import discord
 from discord.ext import commands
@@ -74,13 +75,31 @@ class Personal_WeekRecord(commands.Cog):
         return sum_studytime
 
     def addembed_studytimebar(self, embed, targettime, weekstudymtime):
-        weekstadyhtime = int(weekstudymtime) // 60
-        bar = str(tqdm(initial=weekstadyhtime, total=int(targettime), ncols=77, desc="[達成度]" , bar_format="{desc}{percentage:3.0f}%|{bar}|\n--->現在の積み上げ：{n}h\n--->週の目標時間　：{total}h",))
+        weekstudyhtime = int(weekstudymtime) // 60
+        if weekstudyhtime > int(targettime): # 勉強時間/目標時間が100%を超えた場合の処理
+            bar = str(tqdm(
+                initial=weekstudyhtime, 
+                total=weekstudyhtime, 
+                ncols=77, desc="[達成度]" , 
+                bar_format="{desc}{percentage:3.0f}%|{bar}|\n--->現在の積み上げ：{n}h\n--->週の目標時間　：{total}h"
+                ))
+            # 文字列の末尾の目標時間を以下の変数で置換
+            bar = re.sub(rf"{str(weekstudyhtime)}h$", f"{str(targettime)}h", bar)
+        else: # 勉強時間/目標時間が100%未満の場合の処理
+            bar = str(tqdm(
+                initial=weekstudyhtime, 
+                total=int(targettime), 
+                ncols=77, desc="[達成度]", 
+                bar_format="{desc}{percentage:3.0f}%|{bar}|\n--->現在の積み上げ：{n}h\n--->週の目標時間　：{total}h"
+                ))
         bar = bar.replace(" ", "", 2)
         bar = bar.replace(" ", "----")
         embed.add_field(name=f"📊目標設定( {targettime}時間 )" ,value=bar, inline=False)
         return embed
 
+    def strfembed(self, str):
+        embed = discord.Embed(title=str)
+        return embed
 
     @commands.group(invoke_without_command=True)
     async def result_w(self, ctx, *args):
@@ -95,11 +114,13 @@ class Personal_WeekRecord(commands.Cog):
             if args: # タプルが空かどうか判定
                 if args[0].isdigit(): # 以下、目標時間の引数（int）がある場合
                     embed = self.addembed_studytimebar(embed, args[0], sum_studytime)
-                    await ctx.channel.send(embed=embed)
-                else:
-                    await ctx.channel.send("引数がおかしい")
-            else:
-                await ctx.channel.send(embed=embed)
+                    sendmsg = await ctx.channel.send(embed=embed)
+                    await sendmsg.add_reaction("<:otsukaresama:757813789952573520>")
+                else: # 引数が数字でない場合
+                    await ctx.channel.send(embed=self.strfembed(f"[ {args[0]} ]は無効な引数です。数字を指定してください"))
+            else: # 引数が含まれていない場合
+                sendmsg = await ctx.channel.send(embed=embed)
+                await sendmsg.add_reaction("<:otsukaresama:757813789952573520>")
         else:
             await ctx.send("[ " + ctx.subcommand_passed + " ]は無効な引数です")
 
@@ -114,11 +135,13 @@ class Personal_WeekRecord(commands.Cog):
         if args: # タプルが空かどうか判定
             if args[0].isdigit(): # 以下、目標時間の引数（int）がある場合
                 embed = self.addembed_studytimebar(embed, args[0], sum_studytime)
-                await ctx.channel.send(embed=embed)
-            else:
-                await ctx.channel.send("引数がおかしい")
-        else:
-            await ctx.channel.send(embed=embed)
+                sendmsg = await ctx.channel.send(embed=embed)
+                await sendmsg.add_reaction("<:otsukaresama:757813789952573520>")
+            else: # 引数が数字でない場合
+                await ctx.channel.send(embed=self.strfembed(f"[ {args[0]} ]は無効な引数です。数字を指定してください"))
+        else: # 引数が含まれていない場合
+            sendmsg = await ctx.channel.send(embed=embed)
+            await sendmsg.add_reaction("<:otsukaresama:757813789952573520>")
 
 
 def setup(bot):

--- a/Cogs/Aggregationtime/personalWeekRecord.py
+++ b/Cogs/Aggregationtime/personalWeekRecord.py
@@ -6,6 +6,7 @@ import asyncio
 import urllib.parse
 import json
 import requests
+from tqdm import tqdm
 
 from .weekAggregate import Week_Aggregate
 from .personalDayRecord import Personal_DayRecord
@@ -72,10 +73,17 @@ class Personal_WeekRecord(commands.Cog):
             sum_studytime += int(log.split(",")[-1])
         return sum_studytime
 
+    def addembed_studytimebar(self, embed, targettime, weekstudymtime):
+        weekstadyhtime = int(weekstudymtime) // 60
+        bar = str(tqdm(initial=weekstadyhtime, total=int(targettime), ncols=77, desc="[達成度]" , bar_format="{desc}{percentage:3.0f}%|{bar}|\n--->現在の積み上げ：{n}h\n--->週の目標時間　：{total}h",))
+        bar = bar.replace(" ", "", 2)
+        bar = bar.replace(" ", "----")
+        embed.add_field(name=f"📊目標設定( {targettime}時間 )" ,value=bar, inline=False)
+        return embed
 
 
     @commands.group(invoke_without_command=True)
-    async def result_w(self, ctx):
+    async def result_w(self, ctx, *args):
         if ctx.subcommand_passed is None:
             username = ctx.author.name
             week_days, desc_week = self.getweek_days()
@@ -83,20 +91,34 @@ class Personal_WeekRecord(commands.Cog):
             sendmessage = self.format_userrecord(username, desc_week, sum_studytime, "今週の振り返り")
             print(sendmessage)
             embed = Personal_DayRecord(self.bot).create_twitter_embed(sendmessage)
-            await ctx.channel.send(embed=embed)
+            print(args)
+            if args: # タプルが空かどうか判定
+                if args[0].isdigit(): # 以下、目標時間の引数（int）がある場合
+                    embed = self.addembed_studytimebar(embed, args[0], sum_studytime)
+                    await ctx.channel.send(embed=embed)
+                else:
+                    await ctx.channel.send("引数がおかしい")
+            else:
+                await ctx.channel.send(embed=embed)
         else:
             await ctx.send("[ " + ctx.subcommand_passed + " ]は無効な引数です")
 
-
     @result_w.command()
-    async def ago(self, ctx):
+    async def ago(self, ctx, *args):
         username = ctx.author.name
         lastweek_days, desc_lastweek = self.getlastweek_days()
         sum_studytime = self.aggregate_user_record(username, lastweek_days)
         sendmessage = self.format_userrecord(username, desc_lastweek, sum_studytime, "先週の振り返り")
         print(sendmessage)
         embed = Personal_DayRecord(self.bot).create_twitter_embed(sendmessage)
-        await ctx.channel.send(embed=embed)
+        if args: # タプルが空かどうか判定
+            if args[0].isdigit(): # 以下、目標時間の引数（int）がある場合
+                embed = self.addembed_studytimebar(embed, args[0], sum_studytime)
+                await ctx.channel.send(embed=embed)
+            else:
+                await ctx.channel.send("引数がおかしい")
+        else:
+            await ctx.channel.send(embed=embed)
 
 
 def setup(bot):

--- a/readStudyTime.py
+++ b/readStudyTime.py
@@ -14,10 +14,10 @@ bot = commands.Bot(command_prefix=prefix,intents=intents)
 
 bot.load_extension("Cogs.default")
 
-bot.load_extension("Cogs.Aggregationtime.weekAggregate")
-bot.load_extension("Cogs.Aggregationtime.monthAggregate")
-bot.load_extension("Cogs.Aggregationtime.cronAggregate")
-bot.load_extension("Cogs.Aggregationtime.personalDayRecord")
+#bot.load_extension("Cogs.Aggregationtime.weekAggregate")
+#bot.load_extension("Cogs.Aggregationtime.monthAggregate")
+#bot.load_extension("Cogs.Aggregationtime.cronAggregate")
+#bot.load_extension("Cogs.Aggregationtime.personalDayRecord")
 bot.load_extension("Cogs.Aggregationtime.personalWeekRecord")
 
 

--- a/readStudyTime.py
+++ b/readStudyTime.py
@@ -14,10 +14,10 @@ bot = commands.Bot(command_prefix=prefix,intents=intents)
 
 bot.load_extension("Cogs.default")
 
-#bot.load_extension("Cogs.Aggregationtime.weekAggregate")
-#bot.load_extension("Cogs.Aggregationtime.monthAggregate")
-#bot.load_extension("Cogs.Aggregationtime.cronAggregate")
-#bot.load_extension("Cogs.Aggregationtime.personalDayRecord")
+bot.load_extension("Cogs.Aggregationtime.weekAggregate")
+bot.load_extension("Cogs.Aggregationtime.monthAggregate")
+bot.load_extension("Cogs.Aggregationtime.cronAggregate")
+bot.load_extension("Cogs.Aggregationtime.personalDayRecord")
 bot.load_extension("Cogs.Aggregationtime.personalWeekRecord")
 
 

--- a/readStudyTime.py
+++ b/readStudyTime.py
@@ -18,6 +18,7 @@ bot.load_extension("Cogs.Aggregationtime.weekAggregate")
 bot.load_extension("Cogs.Aggregationtime.monthAggregate")
 bot.load_extension("Cogs.Aggregationtime.cronAggregate")
 bot.load_extension("Cogs.Aggregationtime.personalDayRecord")
+bot.load_extension("Cogs.Aggregationtime.personalWeekRecord")
 
 
 bot.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ python-dotenv==0.10.3
 python-magic==0.4.15
 requests==2.25.1
 six==1.15.0
+tqdm==4.56.0
 urllib3==1.26.2
 websockets==8.1
 yarl==1.5.1


### PR DESCRIPTION
- 送信されたembedに「お疲れ様」の絵文字を自動付与
- 週の月〜日までのいつ実行されても今週の月から、先週の月から集計されるようにしました

# コマンド説明
```sh
# 基本的な説明
- ¥result_w
- 自分の1週間の勉強集計を出力する

# コマンドの使い方（例）
## 今週の勉強集計
1. ¥result_w
## 今週の勉強集計＋目標時間（数字）を指定した場合、進捗を割合で出力
2. ¥result_w 30

## 先週の勉強集計
3. ¥result_w ago
## 先週の勉強集計＋目標時間（数字）を指定した場合、進捗を割合で出力
4. ¥result_w ago 30
```