### PR TITLE
[#34] embedメッセージのテンプレートの途中に空白行を追加

### DIFF
--- a/Cogs/Aggregationtime/personalDayRecord.py
+++ b/Cogs/Aggregationtime/personalDayRecord.py
@@ -76,6 +76,7 @@ class Personal_DayRecord(commands.Cog):
 #今日の積み上げ 
 - 
 -
+
 #もくもくオンライン勉強会 
 [ {day}の勉強時間 ]
 ---> {totalStudyTime}


### PR DESCRIPTION
- ツイッターに投稿する時毎回途中で空の改行を入れていたのでテンプレートの修正
- 見やすくするため