### PR TITLE
Discordコマンドを管理者しか起動できないように権限を見直しました

### DIFF
--- a/Cogs/Aggregationtime/monthAggregate.py
+++ b/Cogs/Aggregationtime/monthAggregate.py
@@ -14,7 +14,7 @@ class Month_Aggregate(commands.Cog):
         self.MAX_SEND_MESSAGE_LENGTH = 2000
 
     @commands.command()
-    # @commands.has_permissions(administrator=True)
+    @commands.has_permissions(administrator=True)
     async def admin_monthresult(self, ctx):
         message = ctx.message
         print(f"Used Command :{ctx.invoked_with} (User){message.author.name}")

--- a/Cogs/Aggregationtime/weekAggregate.py
+++ b/Cogs/Aggregationtime/weekAggregate.py
@@ -276,8 +276,8 @@ class Week_Aggregate(commands.Cog):
                 strtoday, days, user_records, desc_lastmonth)
         return result
 
-    @ commands.command()
-    @ commands.has_permissions(administrator=True)
+    @commands.command()
+    @commands.has_permissions(administrator=True)
     async def admin_weekresult(self, ctx):
         message = ctx.message
         print(f"Used Command :{ctx.invoked_with} (User){message.author.name}")


### PR DESCRIPTION
- 月間処理のコマンドが管理者のみ実行できるよう修正
- 週間処理のコマンド周辺にタイポを見つけたので修正